### PR TITLE
Fail early if time is behind on agent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 puppet_run_only: false
+puppetize_time_difference: 60

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,23 @@
   template: src='puppet.conf' dest='/etc/puppet/puppet.conf'
   tags: ['configure_puppet_client']
 
+# We hope that it takes longer than default 60s to get facts from puppetmaster
+- name: set epoch time + {{ puppetize_time_difference }}s as my_puppetize_time
+  set_fact:
+    my_puppetize_time: "{{ ansible_date_time.epoch|int + puppetize_time_difference }}"
+
+- name: grab time from puppetmaster
+  setup:
+    gather_subset: min
+  register: reg_puppetmaster_facts
+  delegate_to: "{{ puppetmaster }}"
+
+- name: We do not want to create a certificate that is not valid until time has caught up with time on the puppetmaster
+  fail:
+    msg: Time is too much in the past on the agent ({{ my_puppetize_time }} vs {{ reg_puppetmaster_facts.ansible_facts.ansible_date_time.epoch }}), fail before we create a certificate on the puppet agent
+  when: my_puppetize_time < reg_puppetmaster_facts.ansible_facts.ansible_date_time.epoch
+#
+
 - name: request cert to be signed on puppetmaster
   command: "puppet agent --test --noop"
   #become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,8 @@
   setup:
     gather_subset: min
   register: reg_puppetmaster_facts
+  remote_user: "{{ lookup('env', 'USER') }}"
+  become: yes
   delegate_to: "{{ puppetmaster }}"
 
 - name: We do not want to create a certificate that is not valid until time has caught up with time on the puppetmaster


### PR DESCRIPTION
Let's say time is out of sync on the node to be puppetized and
it's 11:23 while on the puppetmaster it's in sync and it's 12:23.

The certificate request generated by puppet-agent will be from
11:23 but the CA on the puppetmaster will generate a certificate that is valid
from 12:23.

This PR avoids creating a certificate request on the puppet agent because
fixing this means fixing time, removing on the agent and revoking the
certificate on the puppetmaster.

If there's longer than 60 seconds between gathering facts of the node to be
puppetized and the task in this role that gets the time from the
puppetmaster, then the new variable {{ puppetize_time_difference }} may increased.