### PR TITLE
Only get ansible_date_time from puppetmaster facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ License
 
 MIT
 
+Testing
+-------
+
+This bit is manual, we do some testing in this role already but it does not setup a puppetmaster+agent.
+
+Basic environment needed: an agent and a puppetmaster on different VMs/tainers with different FQDNs.
+
+When testing this role it's a good idea to run it on a node:
+  - which is already puppetized from before
+  - which is not puppetized before (generate CSR and sign the certificate)
+  - where we only run some tasks with "puppet_run_only=True"
+
 Author Information
 ------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,9 +42,10 @@
     my_puppetize_time: "{{ ansible_date_time.epoch|int + puppetize_time_difference }}"
   when: puppet_run_only == False
 
-- name: grab time from puppetmaster
+- name: grab ansible_date_time from puppetmaster
   setup:
     gather_subset: min
+    filter: "ansible_date_time*"
   register: reg_puppetmaster_facts
   remote_user: "{{ lookup('env', 'USER') }}"
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,6 +50,7 @@
   remote_user: "{{ lookup('env', 'USER') }}"
   become: yes
   delegate_to: "{{ puppetmaster }}"
+  delegate_facts: True
   when: puppet_run_only == False
 
 - name: We do not want to create a certificate that is not valid until time has caught up with time on the puppetmaster

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,12 +36,12 @@
   template: src='puppet.conf' dest='/etc/puppet/puppet.conf'
   tags: ['configure_puppet_client']
 
-# We hope that it takes longer than default 60s to get facts from puppetmaster
 - name: set epoch time + {{ puppetize_time_difference }}s as my_puppetize_time
   set_fact:
     my_puppetize_time: "{{ ansible_date_time.epoch|int + puppetize_time_difference }}"
   when: puppet_run_only == False
 
+  # If this takes longer than 60s (value of puppetize_time_difference) the fail: task below would give a false-negative error.
 - name: grab ansible_date_time from puppetmaster
   setup:
     gather_subset: min


### PR DESCRIPTION
Without this there is a {{ ansible_fqdn }} populated for the
puppetmaster, so when it gets the command via the delegate_to task it
will fill {{ ansible_fqdn }} in with its own hostname

 - #CCCP-2827