### PR TITLE
Use inventory_hostname instead of ansible_fqdn

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,17 +41,17 @@
   #become: yes
   register: puppet_result
   args:
-    creates: "/var/lib/puppet/ssl/certificate_requests/{{ ansible_fqdn }}.pem"
+    creates: "/var/lib/puppet/ssl/certificate_requests/{{ inventory_hostname }}.pem"
   failed_when: (puppet_result.rc != 1) and (puppet_result.rc != 0)
   tags: ['puppet_cert_bootstrap']
   when: puppet_run_only == False
 
 - name: sign cert on puppetmaster
-  command: "puppet cert sign {{ ansible_fqdn }}"
+  command: "puppet cert sign {{ inventory_hostname }}"
   remote_user: "{{ lookup('env', 'USER') }}"
   become: yes
   args:
-    removes: "/var/lib/puppet/ssl/ca/requests/{{ ansible_fqdn }}.pem"
+    removes: "/var/lib/puppet/ssl/ca/requests/{{ inventory_hostname }}.pem"
   delegate_to: "{{ puppetmaster }}"
   tags: ['puppet_cert_bootstrap']
   when: puppet_run_only == false


### PR DESCRIPTION
ansible_fqdn requires gathering facts and is not guaranteed to be correct on all nodes.
CCCP-2888