### PR TITLE
Support both Puppet 3 and Puppet4 clients

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,5 +2,5 @@
 puppet_run_only: False
 puppetize_time_difference: 60
 puppetlabs_repo_url: 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
-puppetize_manage_yumrepo: True
+puppetize_manage_yumrepo: False
 ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 puppet_run_only: false
 puppetize_time_difference: 60
+install_alt_puppet_repo: false
+puppetlabs_repo_url: 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@ puppet_run_only: false
 puppetize_time_difference: 60
 install_alt_puppet_repo: false
 puppetlabs_repo_url: 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
+puppetize_manage_yumrepo: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-puppet_run_only: false
+puppet_run_only: False
 puppetize_time_difference: 60
-install_alt_puppet_repo: false
 puppetlabs_repo_url: 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
 puppetize_manage_yumrepo: True
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,8 +97,8 @@
 
 - name: sign cert on puppetmaster
   command: "puppet cert sign {{ inventory_hostname }}"
-  remote_user: "{{ lookup('env', 'USER') }}"
   become: yes
+  become_user: root
   args:
     removes: "/var/lib/puppet/ssl/ca/requests/{{ inventory_hostname }}.pem"
   delegate_to: "{{ puppetmaster }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,7 +106,7 @@
   when: puppet_run_only == false
 
 - name: puppetize!
-  command: "puppet agent -t --http_compression"
+  command: "puppet agent -t"
   register: puppet_result
   changed_when: puppet_result.rc == 2
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,18 @@
 ---
 
 - name: install puppetlabs repo
-  yum: name={{item}} state=present validate_certs=no
+  yum:
+    name: "{{item}}"
+    state: present
+    validate_certs: no
   with_items:
     - "{{puppetlabs_repo_url}}"
   when: puppetize_manage_yumrepo
 
 - name: install puppet
-  yum: name='puppet' state=present
+  yum:
+    name: 'puppet'
+    state: present
   tags: ['install_puppet_client']
   when: puppet_run_only == False
 
@@ -60,7 +65,9 @@
     - puppet_file_content.rc == 0
 
 - name: template in puppet config
-  template: src="{{ puppet_conf_source }}" dest="{{ puppet_etc_dir }}/puppet.conf"
+  template: 
+    src: "{{ puppet_conf_source }}" 
+    dest: "{{ puppet_etc_dir }}/puppet.conf"
   tags: ['configure_puppet_client']
 
   # If this takes longer than 60s (value of puppetize_time_difference) the fail: task below would give a false-negative error.
@@ -89,11 +96,9 @@
     - reg_puppetmaster_facts.ansible_facts is defined
     - puppet_run_only == False
     - my_puppetize_time < reg_puppetmaster_facts.ansible_facts.ansible_date_time.epoch
-#
 
 - name: request cert to be signed on puppetmaster
   command: "{{ puppet_agent_bin_path }} agent --test --noop"
-  #become: yes
   register: puppet_result
   args:
     creates: "/var/lib/puppet/ssl/certificate_requests/{{ inventory_hostname }}.pem"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,12 +107,12 @@
   when: puppet_run_only == False
 
 - name: sign cert on puppetmaster
-  command: "{{ puppet_agent_bin_path }} cert sign {{ ansible_fqdn }}"
+  command: "{{ puppet_agent_bin_path }} cert sign {{ inventory_hostname }}"
   remote_user: "{{ lookup('env', 'USER') }}"
   become: yes
   become_user: root
   args:
-    removes: "{{ puppet_ca_request_path }}/{{ ansible_fqdn }}.pem"
+    removes: "{{ puppet_ca_request_path }}/{{ inventory_hostname }}.pem"
   delegate_to: "{{ puppetmaster }}"
   tags: ['puppet_cert_bootstrap']
   when: puppet_run_only == false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,11 +3,9 @@
   yum: name={{item}} state=present validate_certs=no
   with_items:
     - "{{puppetlabs_repo_url}}"
-  when: install_alt_puppet_repo
 
-- shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
-  ignore_errors: True
-  when: install_alt_puppet_repo
+#- shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
+#  ignore_errors: True
 
 - name: install puppet
   yum: name='puppet' state=present
@@ -16,7 +14,7 @@
 
 
 - name: Get puppet.conf contents
-  command: grep environment /etc/puppet/puppet.conf
+  command: grep environment /etc/puppetlabs/puppet/puppet.conf
   register: puppet_file_content
   failed_when: puppet_file_content.rc > 1
   tags: ['configure_puppet_client', 'testing']
@@ -43,7 +41,7 @@
     - puppet_file_content.rc == 0
 
 - name: copy puppet config
-  template: src='puppet.conf' dest='/etc/puppet/puppet.conf'
+  template: src='puppet.conf' dest='/etc/puppetlabs/puppet/puppet.conf'
   tags: ['configure_puppet_client']
 
   # If this takes longer than 60s (value of puppetize_time_difference) the fail: task below would give a false-negative error.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+### PoC for Puppet4
+- name: install puppetlabs repo
+  yum: name={{item}} state=present
+  with_items:
+    - "{{puppetlabs_repo_url}}"
+  when: install_alt_puppet_repo
+###
+
 - name: install puppet
   yum: name='puppet' state=present
   tags: ['install_puppet_client']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,12 +18,12 @@
   ignore_errors: True
   changed_when: False
 
-- name: set fact puppetize_version to 3
+- name: set fact puppetize_version to 3 if /etc/puppetlabs does not exist
   set_fact:
     puppetize_version: 3
   when: reg_puppetize_stat_puppetlabs.stat.exists == False
 
-- name: set fact puppetize_version to 4
+- name: set fact puppetize_version to 4 if /etc/puppetlabs does exists
   set_fact:
     puppetize_version: 4
   when: reg_puppetize_stat_puppetlabs.stat.exists
@@ -32,8 +32,8 @@
   include_vars:
     file: "puppetize_vars_{{ puppetize_version }}.yml"
 
-- name: Get puppet.conf contents
-  command: "grep environment {{ puppet_etc_dir }}/puppet.conf"
+- name: Check if puppet.conf contains "environment ="
+  command: "grep 'environment =' {{ puppet_etc_dir }}/puppet.conf"
   register: puppet_file_content
   failed_when: puppet_file_content.rc > 1
   tags: ['configure_puppet_client', 'testing']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: install puppetlabs repo
   yum: name={{item}} state=present validate_certs=no
   with_items:
@@ -10,8 +11,29 @@
   tags: ['install_puppet_client']
   when: puppet_run_only == False
 
+- name: stat /etc/puppetlabs
+  stat:
+    path: /etc/puppetlabs
+  register: reg_puppetize_stat_puppetlabs
+  ignore_errors: True
+  changed_when: False
+
+- name: set fact puppetize_version to 3
+  set_fact:
+    puppetize_version: 3
+  when: reg_puppetize_stat_puppetlabs.stat.exists == False
+
+- name: set fact puppetize_version to 4
+  set_fact:
+    puppetize_version: 4
+  when: reg_puppetize_stat_puppetlabs.stat.exists
+
+- name: include vars depending on puppet version
+  include_vars:
+    file: "puppetize_vars_{{ puppetize_version }}.yml"
+
 - name: Get puppet.conf contents
-  command: grep environment /etc/puppetlabs/puppet/puppet.conf
+  command: "grep environment {{ puppet_etc_dir }}/puppet.conf"
   register: puppet_file_content
   failed_when: puppet_file_content.rc > 1
   tags: ['configure_puppet_client', 'testing']
@@ -37,8 +59,8 @@
     - puppet_environment == "production" or puppet_environment == "test"
     - puppet_file_content.rc == 0
 
-- name: copy puppet config
-  template: src='puppet.conf' dest='/etc/puppetlabs/puppet/puppet.conf'
+- name: template in puppet config
+  template: src="{{ puppet_conf_source }}" dest="{{ puppet_etc_dir }}/puppet.conf"
   tags: ['configure_puppet_client']
 
   # If this takes longer than 60s (value of puppetize_time_difference) the fail: task below would give a false-negative error.
@@ -70,7 +92,7 @@
 #
 
 - name: request cert to be signed on puppetmaster
-  command: "/opt/puppetlabs/bin/puppet agent --test --noop"
+  command: "{{ puppet_agent_bin_path }} agent --test --noop"
   #become: yes
   register: puppet_result
   args:
@@ -80,17 +102,18 @@
   when: puppet_run_only == False
 
 - name: sign cert on puppetmaster
-  command: "puppet cert sign {{ inventory_hostname }}"
+  command: "{{ puppet_agent_bin_path }} cert sign {{ ansible_fqdn }}"
+  remote_user: "{{ lookup('env', 'USER') }}"
   become: yes
   become_user: root
   args:
-    removes: "/var/lib/puppet/ssl/ca/requests/{{ inventory_hostname }}.pem"
+    removes: "{{ puppet_ca_request_path }}/{{ ansible_fqdn }}.pem"
   delegate_to: "{{ puppetmaster }}"
   tags: ['puppet_cert_bootstrap']
   when: puppet_run_only == false
 
 - name: puppetize!
-  command: "/opt/puppetlabs/bin/puppet agent -t"
+  command: "{{ puppet_agent_bin_path }} agent -t"
   register: puppet_result
   changed_when: puppet_result.rc == 2
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,19 +4,8 @@
   with_items:
     - "{{puppetlabs_repo_url}}"
   when: install_alt_puppet_repo
+
 - shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
-  ignore_errors: True
-  when: install_alt_puppet_repo
-- shell: ln -s /opt/puppetlabs/bin/facter /usr/local/bin/
-  ignore_errors: True
-  when: install_alt_puppet_repo
-- shell: ln -s /opt/puppetlabs/bin/puppet* /usr/local/bin/
-  ignore_errors: True
-  when: install_alt_puppet_repo
-- shell: ln -s /opt/puppetlabs/bin/mco /usr/local/bin/
-  ignore_errors: True
-  when: install_alt_puppet_repo
-- shell: ln -s /opt/puppetlabs/bin/hiera /usr/local/bin/
   ignore_errors: True
   when: install_alt_puppet_repo
 
@@ -86,7 +75,7 @@
 #
 
 - name: request cert to be signed on puppetmaster
-  command: "puppet agent --test --noop"
+  command: "/opt/puppetlabs/bin/puppet agent --test --noop"
   #become: yes
   register: puppet_result
   args:
@@ -106,7 +95,7 @@
   when: puppet_run_only == false
 
 - name: puppetize!
-  command: "puppet agent -t"
+  command: "/opt/puppetlabs/bin/puppet agent -t"
   register: puppet_result
   changed_when: puppet_result.rc == 2
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,19 @@
   when: install_alt_puppet_repo
 
 - shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
-  ignore_errors: yes
+  ignore_errors: True
+  when: install_alt_puppet_repo
+- shell: ln -s /opt/puppetlabs/bin/facter /usr/local/bin/
+  ignore_errors: True
+  when: install_alt_puppet_repo
+- shell: ln -s /opt/puppetlabs/bin/puppet* /usr/local/bin/
+  ignore_errors: True
+  when: install_alt_puppet_repo
+- shell: ln -s /opt/puppetlabs/bin/mco /usr/local/bin/
+  ignore_errors: True
+  when: install_alt_puppet_repo
+- shell: ln -s /opt/puppetlabs/bin/hiera /usr/local/bin/
+  ignore_errors: True
   when: install_alt_puppet_repo
 ###
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,15 +3,12 @@
   yum: name={{item}} state=present validate_certs=no
   with_items:
     - "{{puppetlabs_repo_url}}"
-
-#- shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
-#  ignore_errors: True
+  when: puppetize_manage_yumrepo
 
 - name: install puppet
   yum: name='puppet' state=present
   tags: ['install_puppet_client']
   when: puppet_run_only == False
-
 
 - name: Get puppet.conf contents
   command: grep environment /etc/puppetlabs/puppet/puppet.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -101,7 +101,7 @@
   command: "{{ puppet_agent_bin_path }} agent --test --noop"
   register: puppet_result
   args:
-    creates: "/var/lib/puppet/ssl/certificate_requests/{{ inventory_hostname }}.pem"
+    creates: "{{ puppet_cert_request_path }}/{{ inventory_hostname }}.pem"
   failed_when: (puppet_result.rc != 1) and (puppet_result.rc != 0)
   tags: ['puppet_cert_bootstrap']
   when: puppet_run_only == False
@@ -115,7 +115,7 @@
     removes: "{{ puppet_ca_request_path }}/{{ inventory_hostname }}.pem"
   delegate_to: "{{ puppetmaster }}"
   tags: ['puppet_cert_bootstrap']
-  when: puppet_run_only == false
+  when: puppet_run_only == False
 
 - name: puppetize!
   command: "{{ puppet_agent_bin_path }} agent -t"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,7 +93,7 @@
   when: puppet_run_only == false
 
 - name: puppetize!
-  command: "puppet agent -t"
+  command: "puppet agent -t --http_compression"
   register: puppet_result
   changed_when: puppet_result.rc == 2
   failed_when: (puppet_result.rc != 2) and (puppet_result.rc != 0)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,8 +37,8 @@
   include_vars:
     file: "puppetize_vars_{{ puppetize_version }}.yml"
 
-- name: Check if puppet.conf contains "environment ="
-  command: "grep 'environment =' {{ puppet_etc_dir }}/puppet.conf"
+- name: Check if puppet.conf contains environment
+  command: "grep environment {{ puppet_etc_dir }}/puppet.conf"
   register: puppet_file_content
   failed_when: puppet_file_content.rc > 1
   tags: ['configure_puppet_client', 'testing']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,9 @@
 ---
-### PoC for Puppet4
 - name: install puppetlabs repo
   yum: name={{item}} state=present validate_certs=no
   with_items:
     - "{{puppetlabs_repo_url}}"
   when: install_alt_puppet_repo
-
 - shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
   ignore_errors: True
   when: install_alt_puppet_repo
@@ -21,7 +19,6 @@
 - shell: ln -s /opt/puppetlabs/bin/hiera /usr/local/bin/
   ignore_errors: True
   when: install_alt_puppet_repo
-###
 
 - name: install puppet
   yum: name='puppet' state=present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,10 @@
   with_items:
     - "{{puppetlabs_repo_url}}"
   when: install_alt_puppet_repo
+
+- shell: "ln -s /etc/puppetlabs/puppet /etc/puppet"
+  ignore_errors: yes
+  when: install_alt_puppet_repo
 ###
 
 - name: install puppet

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 ### PoC for Puppet4
 - name: install puppetlabs repo
-  yum: name={{item}} state=present
+  yum: name={{item}} state=present validate_certs=no
   with_items:
     - "{{puppetlabs_repo_url}}"
   when: install_alt_puppet_repo

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,15 +1,15 @@
 [main]
     # The Puppet log directory.
     # The default value is '$vardir/log'.
-    logdir = /var/log/puppet
+    #logdir = /var/log/puppet
 
     # Where Puppet PID files are kept.
     # The default value is '$vardir/run'.
-    rundir = /var/run/puppet
+    #rundir = /var/run/puppet
 
     # Where SSL certificates are kept.
     # The default value is '$confdir/ssl'.
-    ssldir = $vardir/ssl
+    #ssldir = $vardir/ssl
 
 [agent]
     # The file in which puppetd stores a list of the classes
@@ -17,12 +17,11 @@
     # the separate ``puppet`` executable using the ``--loadclasses``
     # option.
     # The default value is '$confdir/classes.txt'.
-    classfile = $vardir/classes.txt
+    #classfile = $vardir/classes.txt
 
     # Where puppetd caches the local configuration.  An
     # extension indicating the cache format is added automatically.
     # The default value is '$confdir/localconfig'.
-    localconfig = $vardir/localconfig
+    #localconfig = $vardir/localconfig
     server = {{ puppetmaster_fqdn }}
     environment = {{ puppet_environment }}
-#    libdir = /var/lib/puppet/lib2

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,12 +1,28 @@
 [main]
+    # The Puppet log directory.
+    # The default value is '$vardir/log'.
     logdir = /var/log/puppet
+
+    # Where Puppet PID files are kept.
+    # The default value is '$vardir/run'.
     rundir = /var/run/puppet
+
+    # Where SSL certificates are kept.
+    # The default value is '$confdir/ssl'.
     ssldir = $vardir/ssl
 
 [agent]
+    # The file in which puppetd stores a list of the classes
+    # associated with the retrieved configuratiion.  Can be loaded in
+    # the separate ``puppet`` executable using the ``--loadclasses``
+    # option.
+    # The default value is '$confdir/classes.txt'.
     classfile = $vardir/classes.txt
+
+    # Where puppetd caches the local configuration.  An
+    # extension indicating the cache format is added automatically.
+    # The default value is '$confdir/localconfig'.
     localconfig = $vardir/localconfig
     server = {{ puppetmaster_fqdn }}
     environment = {{ puppet_environment }}
-
 #    libdir = /var/lib/puppet/lib2

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -1,28 +1,12 @@
 [main]
-    # The Puppet log directory.
-    # The default value is '$vardir/log'.
     logdir = /var/log/puppet
-
-    # Where Puppet PID files are kept.
-    # The default value is '$vardir/run'.
     rundir = /var/run/puppet
-
-    # Where SSL certificates are kept.
-    # The default value is '$confdir/ssl'.
     ssldir = $vardir/ssl
 
 [agent]
-    # The file in which puppetd stores a list of the classes
-    # associated with the retrieved configuratiion.  Can be loaded in
-    # the separate ``puppet`` executable using the ``--loadclasses``
-    # option.
-    # The default value is '$confdir/classes.txt'.
     classfile = $vardir/classes.txt
-
-    # Where puppetd caches the local configuration.  An
-    # extension indicating the cache format is added automatically.
-    # The default value is '$confdir/localconfig'.
     localconfig = $vardir/localconfig
     server = {{ puppetmaster_fqdn }}
     environment = {{ puppet_environment }}
-    libdir = /var/lib/puppet/lib2
+
+#    libdir = /var/lib/puppet/lib2

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -26,3 +26,4 @@
     #localconfig = $vardir/localconfig
     server = {{ puppetmaster_fqdn }}
     environment = {{ puppet_environment }}
+    environmentpath = $codedir/environments

--- a/templates/puppet.conf
+++ b/templates/puppet.conf
@@ -10,6 +10,7 @@
     # Where SSL certificates are kept.
     # The default value is '$confdir/ssl'.
     #ssldir = $vardir/ssl
+    environment = {{ puppet_environment }}
 
 [agent]
     # The file in which puppetd stores a list of the classes

--- a/templates/puppet3.conf.j2
+++ b/templates/puppet3.conf.j2
@@ -1,16 +1,16 @@
+# {{ ansible_managed }}
 [main]
     # The Puppet log directory.
     # The default value is '$vardir/log'.
-    #logdir = /var/log/puppet
+    logdir = /var/log/puppet
 
     # Where Puppet PID files are kept.
     # The default value is '$vardir/run'.
-    #rundir = /var/run/puppet
+    rundir = /var/run/puppet
 
     # Where SSL certificates are kept.
     # The default value is '$confdir/ssl'.
-    #ssldir = $vardir/ssl
-    environment = {{ puppet_environment }}
+    ssldir = $vardir/ssl
 
 [agent]
     # The file in which puppetd stores a list of the classes
@@ -18,12 +18,12 @@
     # the separate ``puppet`` executable using the ``--loadclasses``
     # option.
     # The default value is '$confdir/classes.txt'.
-    #classfile = $vardir/classes.txt
+    classfile = $vardir/classes.txt
 
     # Where puppetd caches the local configuration.  An
     # extension indicating the cache format is added automatically.
     # The default value is '$confdir/localconfig'.
-    #localconfig = $vardir/localconfig
+    localconfig = $vardir/localconfig
     server = {{ puppetmaster_fqdn }}
     environment = {{ puppet_environment }}
-    environmentpath = $codedir/environments
+    libdir = /var/lib/puppet/lib2

--- a/templates/puppet4.conf.j2
+++ b/templates/puppet4.conf.j2
@@ -12,6 +12,7 @@
     # The default value is '$confdir/ssl'.
     #ssldir = $vardir/ssl
     environment = {{ puppet_environment }}
+    environmentpath = $codedir/environments
 
 [agent]
     # The file in which puppetd stores a list of the classes
@@ -26,5 +27,4 @@
     # The default value is '$confdir/localconfig'.
     #localconfig = $vardir/localconfig
     server = {{ puppetmaster_fqdn }}
-    environment = {{ puppet_environment }}
-    environmentpath = $codedir/environments
+    certname = {{ ansible_fqdn }}

--- a/templates/puppet4.conf.j2
+++ b/templates/puppet4.conf.j2
@@ -27,4 +27,4 @@
     # The default value is '$confdir/localconfig'.
     #localconfig = $vardir/localconfig
     server = {{ puppetmaster_fqdn }}
-    certname = {{ ansible_fqdn }}
+    certname = {{ inventory_hostname }}

--- a/templates/puppet4.conf.j2
+++ b/templates/puppet4.conf.j2
@@ -1,0 +1,30 @@
+# {{ ansible_managed }}
+[main]
+    # The Puppet log directory.
+    # The default value is '$vardir/log'.
+    #logdir = /var/log/puppet
+
+    # Where Puppet PID files are kept.
+    # The default value is '$vardir/run'.
+    #rundir = /var/run/puppet
+
+    # Where SSL certificates are kept.
+    # The default value is '$confdir/ssl'.
+    #ssldir = $vardir/ssl
+    environment = {{ puppet_environment }}
+
+[agent]
+    # The file in which puppetd stores a list of the classes
+    # associated with the retrieved configuratiion.  Can be loaded in
+    # the separate ``puppet`` executable using the ``--loadclasses``
+    # option.
+    # The default value is '$confdir/classes.txt'.
+    #classfile = $vardir/classes.txt
+
+    # Where puppetd caches the local configuration.  An
+    # extension indicating the cache format is added automatically.
+    # The default value is '$confdir/localconfig'.
+    #localconfig = $vardir/localconfig
+    server = {{ puppetmaster_fqdn }}
+    environment = {{ puppet_environment }}
+    environmentpath = $codedir/environments

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -120,8 +120,8 @@ function test_playbook(){
 }
 function extra_tests(){
 
-    echo "TEST: ls /etc/puppet/*"
-    ls /etc/puppet/
+    echo "TEST: ls /etc/puppetlabs/puppet/*"
+    ls /etc/puppetlabs/puppet/
 
 }
 

--- a/vars/puppetize_vars_3.yml
+++ b/vars/puppetize_vars_3.yml
@@ -1,0 +1,9 @@
+---
+
+puppet_etc_dir: "/etc/puppet"
+puppet_conf_source: "puppet3.conf.j2"
+puppet_agent_bin_path: "puppet"
+puppet_cert_request_path: "/var/lib/puppet/ssl/certificate_requests/"
+puppet_ca_request_path: "/var/lib/puppet/ssl/ca/requests/"
+
+...

--- a/vars/puppetize_vars_4.yml
+++ b/vars/puppetize_vars_4.yml
@@ -3,7 +3,7 @@
 puppet_etc_dir: "/etc/puppetlabs/puppet"
 puppet_conf_source: "puppet4.conf.j2"
 puppet_agent_bin_path: "/opt/puppetlabs/bin/puppet"
-puppet_cert_request_path: "/opt/puppetlabs/puppet/cache/ssl/certificate_requests/"
+puppet_cert_request_path: "/etc/puppetlabs/puppet/ssl/certificate_requests"
 puppet_ca_request_path: "/etc/puppetlabs/puppet/ssl/ca/requests/"
 
 ...

--- a/vars/puppetize_vars_4.yml
+++ b/vars/puppetize_vars_4.yml
@@ -1,0 +1,9 @@
+---
+
+puppet_etc_dir: "/etc/puppetlabs/puppet"
+puppet_conf_source: "puppet4.conf.j2"
+puppet_agent_bin_path: "/opt/puppetlabs/bin/puppet"
+puppet_cert_request_path: "/opt/puppetlabs/puppet/cache/ssl/certificate_requests/"
+puppet_ca_request_path: "/etc/puppetlabs/puppet/ssl/ca/requests/"
+
+...


### PR DESCRIPTION
This incorporates many changes also from @junousi with https://github.com/CSCfi/polte

General idea:
 - I can run the same role against both a puppet3 and a puppet4 client.

Tested:
 - with CentOS7 puppet3 & puppet4
 - with --check and without
 - in a playbook with facts and another without facts

This does not fix any "I have to puppetize several times for things to work"

Summary of changes:
 - also have option to install puppetlabs-release-pc1 collection 1, defaults to False
 - check what version we have and set a fact called puppetize_version depending on that
 - include_vars depending on puppet version (3 or 4, four is anything with /etc/puppetlabs directory).