### PR TITLE
Enable puppet agent if it was previously disabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ puppetize_time_difference: 60
 puppetlabs_repo_url:
   - 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
 puppetize_manage_yumrepo: False
+puppetize_enable_puppet: False
 # example for yum proxy setup
 #proxy_server_address: "http://myproxyip.example.org:3128"
 #proxy_env:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -116,6 +116,10 @@
   tags: ['puppet_cert_bootstrap']
   when: puppet_run_only == False
 
+- name: enable puppet agent
+  command: "{{ puppet_agent_bin_path }} agent --enable"
+  when: puppetize_enable_puppet
+
 - name: puppetize!
   command: "{{ puppet_agent_bin_path }} agent -t"
   register: puppet_result


### PR DESCRIPTION
If puppet agent has been previously disabled it will still refuse to run
despite being called manually (via ansible).
This allows the role to automatically re enable puppet before running.