### PR TITLE
Add option for puppet srv domains

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,4 +10,6 @@ puppetize_manage_yumrepo: False
 #    ftp_proxy: "{{proxy_server_address}}"
 #    http_proxy: "{{proxy_server_address}}"
 #    https_proxy: "{{proxy_server_address}}"
-...
+
+puppetize_srv_domain: ''
+

--- a/templates/puppet4.conf.j2
+++ b/templates/puppet4.conf.j2
@@ -14,6 +14,12 @@
     environment = {{ puppet_environment }}
     environmentpath = $codedir/environments
 
+		{% if puppetize_srv_domain %}
+		use_srv_records = true
+		srv_domain = {{ puppetize_srv_domain }}
+		{% endif %}
+
+
 [agent]
     # The file in which puppetd stores a list of the classes
     # associated with the retrieved configuratiion.  Can be loaded in


### PR DESCRIPTION
If puppetize_srv_domain an srv_domains search record will be added to puppets
configuration.