### PR TITLE
Optionally add more puppet.conf settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,13 @@ puppetlabs_repo_url:
   - 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
 puppetize_manage_yumrepo: False
 puppetize_enable_puppet: False
+
+# examples for extra puppet.conf settings:
+#puppetize_extra_main_params:
+#  - "use_srv_records = true"
+#puppetize_extra_agent_params:
+#  - "summarize = true"
+
 # example for yum proxy setup
 #proxy_server_address: "http://myproxyip.example.org:3128"
 #proxy_env:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     name: "{{ puppetlabs_repo_url }}"
     state: present
     validate_certs: no
-  environment: "{{ proxy_env|default(omit) }}"
+  environment: "{{ proxy_env|default({}) }}"
   when: puppetize_manage_yumrepo
 
 - name: install puppet

--- a/templates/puppet4.conf.j2
+++ b/templates/puppet4.conf.j2
@@ -12,6 +12,12 @@
     # The default value is '$confdir/ssl'.
     #ssldir = $vardir/ssl
 
+{%- if puppetize_extra_main_params is defined -%}
+{% for main_parms in puppetize_extra_main_params %}
+{{ main_parms }}
+{% endfor %}
+{% endif %}
+
 [agent]
     # The file in which puppetd stores a list of the classes
     # associated with the retrieved configuratiion.  Can be loaded in
@@ -28,3 +34,8 @@
     certname = {{ inventory_hostname }}
     environment = {{ puppet_environment }}
     environmentpath = $codedir/environments
+{%- if puppetize_extra_agent_params is defined -%}
+{% for agent_parms in puppetize_extra_agent_params %}
+{{ agent_parms }}
+{% endfor %}
+{% endif %}

--- a/templates/puppet4.conf.j2
+++ b/templates/puppet4.conf.j2
@@ -14,7 +14,7 @@
 
 {% if puppetize_extra_main_params is defined %}
 {% for main_parms in puppetize_extra_main_params %}
-{{ main_parms }}
+    {{ main_parms }}
 {% endfor %}
 {% endif %}
 
@@ -36,6 +36,6 @@
     environmentpath = $codedir/environments
 {% if puppetize_extra_agent_params is defined %}
 {% for agent_parms in puppetize_extra_agent_params %}
-{{ agent_parms }}
+    {{ agent_parms }}
 {% endfor %}
 {% endif %}

--- a/templates/puppet4.conf.j2
+++ b/templates/puppet4.conf.j2
@@ -12,7 +12,7 @@
     # The default value is '$confdir/ssl'.
     #ssldir = $vardir/ssl
 
-{%- if puppetize_extra_main_params is defined -%}
+{% if puppetize_extra_main_params is defined %}
 {% for main_parms in puppetize_extra_main_params %}
 {{ main_parms }}
 {% endfor %}
@@ -34,7 +34,7 @@
     certname = {{ inventory_hostname }}
     environment = {{ puppet_environment }}
     environmentpath = $codedir/environments
-{%- if puppetize_extra_agent_params is defined -%}
+{% if puppetize_extra_agent_params is defined %}
 {% for agent_parms in puppetize_extra_agent_params %}
 {{ agent_parms }}
 {% endfor %}

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -116,12 +116,16 @@ function test_playbook(){
 
 
     echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
-    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --skip-tags puppet_cert_bootstrap,puppet_run || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --skip-tags puppet_cert_bootstrap,puppet_run | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
 }
 function extra_tests(){
 
-    echo "TEST: ls /etc/puppetlabs/puppet/*"
-    ls /etc/puppetlabs/puppet/
+    #echo "TEST: ls /etc/puppetlabs/puppet/*"
+    #ls /etc/puppetlabs/puppet/
+    echo "TEST: ls -l all puppet.confs"
+    find / -type f -name 'puppet.conf' -exec ls -l {} \; 2>&1|grep -v "Permission denied"
+    echo "TEST: cat all puppet.confs"
+    find / -type f -name 'puppet.conf' -exec cat {} \; 2>&1|grep -v "Permission denied"
 
 }
 
@@ -137,7 +141,7 @@ function main(){
     test_playbook_syntax
     test_playbook
     test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,6 +10,7 @@
        - "use_srv_records = true"
      - puppetize_extra_agent_params:
        - "summarize = true"
+     - puppetize_manage_yumrepo: True
 
    roles:
        - ansible-role-puppetize

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,6 +6,10 @@
      - puppet_environment: "branchname"
      - puppetmaster_fqdn: "test.fqdn.example.com"
      - puppetmaster: localhost
+     - puppetize_extra_main_params:
+       - "use_srv_records = true"
+     - puppetize_extra_agent_params:
+       - "summarize = true"
 
    roles:
        - ansible-role-puppetize

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,6 +10,7 @@
        - "use_srv_records = true"
      - puppetize_extra_agent_params:
        - "summarize = true"
+       - "strict_variables = true"
      - puppetize_manage_yumrepo: True
 
    roles:


### PR DESCRIPTION
Two new ansible variables that are lists: puppetize_extra_main_params
 ( for settings under [main] ) and puppetize_extra_agent_params ( for
settings under [agent] ).

Bonus fixes
 - cat puppet.conf as part of testing (nice to be able to verify that puppet.conf looks like we want it)
 - idempotency testing in travis now actually fails if it is not idempotent
 - in testing with travis we try to set the extra settings
 - set environment to an empty dictionary instead of "{{ proxy_env|default(omit) }}" which returned a warning if proxy_env was not set:
<pre>
[WARNING]: could not parse environment value, skipping: [u'{{
proxy_env|default(omit) }}']
</pre>
