### PR TITLE
Support for Debian family systems (v2)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 puppet_run_only: False
 puppetize_time_difference: 60
-puppetlabs_repo_url:
-  - 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
 puppetize_manage_yumrepo: False
 puppetize_enable_puppet: False
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,20 @@
 ---
 
+- name: check for Debian family system
+  stat:
+    path: '/etc/debian_version'
+  register: reg_puppetize_os_debian
+
+- name: set os family fact
+  set_fact:
+    os_family: 'Debian'
+  when: reg_puppetize_os_debian.stat.exists == True
+
+- name: gather os specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "vars/{{ os_family |default('RedHat')}}.yml"
+
 - name: install puppetlabs repo
   yum:
     name: "{{ puppetlabs_repo_url }}"
@@ -9,8 +24,8 @@
   when: puppetize_manage_yumrepo
 
 - name: install puppet
-  yum:
-    name: 'puppet'
+  package:
+    name: "{{ puppetize_puppet_package }}"
     state: present
   tags: ['install_puppet_client']
   when: puppet_run_only == False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,15 +3,18 @@
 - name: check for Debian family system
   stat:
     path: '/etc/debian_version'
+  tags: ['install_puppet_client']
   register: reg_puppetize_os_debian
 
 - name: set os family fact
   set_fact:
     os_family: 'Debian'
+  tags: ['install_puppet_client']
   when: reg_puppetize_os_debian.stat.exists == True
 
 - name: gather os specific variables
   include_vars: "{{ item }}"
+  tags: ['install_puppet_client']
   with_first_found:
     - "vars/{{ os_family |default('RedHat')}}.yml"
 
@@ -21,6 +24,7 @@
     state: present
     validate_certs: no
   environment: "{{ proxy_env|default({}) }}"
+  tags: ['install_puppet_client']
   when: puppetize_manage_yumrepo
 
 - name: install puppet

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,3 @@
+puppetize_puppet_package: 'puppet-agent'
+puppetlabs_repo_url: ''
+

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,4 @@
+puppetize_puppet_package: 'puppet'
+puppetlabs_repo_url:
+  - 'https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm'
+


### PR DESCRIPTION
This changeset allows Debian family systems (including Ubuntu) to be installed.

Unlike the previous attempt (#17, #19) this checks the presence of a debian family file (/etc/debian_version) and sets a fact to Debian if it does and falls back to Redhat family if the file doesn't exist.