### PR TITLE
Increase default puppetize_time_difference to 120

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 puppet_run_only: False
-puppetize_time_difference: 60
+puppetize_time_difference: 120
 puppetize_manage_yumrepo: False
 puppetize_enable_puppet: False
 


### PR DESCRIPTION
Currently the default 60 seconds is a bit too short for busy servers
which causes failures when the ansible run takes too long. 120 is a more
reasonable default.