### PR TITLE
WIP Install old version of leatherman for CentOS 7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,16 @@
   tags: ['install_puppet_client']
   when: puppetize_manage_yumrepo
 
+- name: install old version of leatherman for CentOS7
+  package:
+    name: leatherman-1.3.0-9.el7.x86_64
+    state: present
+  tags: ['install_puppet_client']
+  when:
+    - not puppet_run_only
+    - ansible_facts['os']['name'] == 'CentOS'
+    - ansible_facts['os']['name']['release']['major'] == '7'
+
 - name: install puppet
   package:
     name: "{{ puppetize_puppet_package }}"


### PR DESCRIPTION
This is a possible solution to an issue installing puppet in CentOS 7 (after EOL). Installing puppet 4 (after EOL), installs the latest version of leatherman available in CentOS that is not compatible with puppet. So this PR install first the old version that works with the old version of puppet. But there might be another nicer solution.