### PR TITLE
Import puppetlabs GPG key for puppet-repo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See defaults/main.yml for current defaults, but as some information:
 
 puppet_run_only: Boolean (true or false). Default false. Only run Puppet without installing it.
 puppetize_time_difference: Integer. Default 120. Maximum difference of time to accept the certificate.
-puppetize_manage_yumrepo: Boolean (true or false). Default false. Ensure the YUM repository is configured.
+puppetize_manage_repo: Boolean (true or false). Default false. Ensure the repository is configured.
 puppetize_enable_puppet: Boolean (true or false). Default false. Enable puppet agent.
 noop_run: Boolean (true or false). Default false. Run puppet agent with --noop option that should not apply changes.
 

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -20,6 +20,7 @@
   rpm_key:
     state: present
     key: "https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406"
+  environment: "{{ proxy_env|default({}) }}"
   when: puppetize_manage_repo
 
 - name: install puppetlabs repo

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -16,12 +16,17 @@
     msg: "Either '{{ puppetlabs_repo_url |default('undefined')}}' or '{{ repo_base ~ '/puppet' ~ puppet_version ~ '-release-el-' ~ ansible_facts['distribution_major_version'] ~ '.noarch.rpm' }}'"
   when: puppetize_manage_repo
 
+- name: Import puppetlabs GPG key
+  rpm_key:
+    state: present
+    key: "https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406"
+  when: puppetize_manage_repo
+
 - name: install puppetlabs repo
   yum:
     name: "{{ puppetlabs_repo_url | default(repo_base ~ '/puppet' ~ puppet_version ~ '-release-el-' ~ ansible_facts['distribution_major_version'] ~ '.noarch.rpm') }}"
     state: present
     validate_certs: no
-    disable_gpg_check: yes
   environment: "{{ proxy_env|default({}) }}"
   tags: ['install_puppet_client']
   when: puppetize_manage_repo

--- a/tasks/install_RedHat.yml
+++ b/tasks/install_RedHat.yml
@@ -21,6 +21,7 @@
     name: "{{ puppetlabs_repo_url | default(repo_base ~ '/puppet' ~ puppet_version ~ '-release-el-' ~ ansible_facts['distribution_major_version'] ~ '.noarch.rpm') }}"
     state: present
     validate_certs: no
+    disable_gpg_check: yes
   environment: "{{ proxy_env|default({}) }}"
   tags: ['install_puppet_client']
   when: puppetize_manage_repo

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -11,7 +11,7 @@
      - puppetize_extra_agent_params:
        - "summarize = true"
        - "strict_variables = true"
-     - puppetize_manage_yumrepo: True
+     - puppetize_manage_repo: True
 
    roles:
        - ansible-role-puppetize

--- a/tests/test_factless.yml
+++ b/tests/test_factless.yml
@@ -12,7 +12,7 @@
      - puppetize_extra_agent_params:
        - "summarize = true"
        - "strict_variables = true"
-     - puppetize_manage_yumrepo: True
+     - puppetize_manage_repo: True
 
    roles:
        - ansible-role-puppetize


### PR DESCRIPTION
This is most probably symptom of ansible version update which we need to do to get it support AlmaLinux better. GPG check is disabled only when we install puppet5-repo package so shouldn't be that big risk.
