### PR TITLE
Increase default puppetize_time_difference

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 puppet_run_only: false
-puppetize_time_difference: 120
+puppetize_time_difference: 1800
 puppetize_manage_repo: false
 puppetize_enable_puppet: false
 


### PR DESCRIPTION
We periodically ecounter issues when we run this role against a large number of nodes. This is due to the value of puppetize_time_difference being too small. This commit increases it to half an hour.